### PR TITLE
Upgrade bullseye

### DIFF
--- a/6.12.0-bullseye/Dockerfile
+++ b/6.12.0-bullseye/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:bullseye-slim
+
+# Preset locale to en_US.UTF-8
+# https://docs.docker.com/samples/library/debian/#locales
+RUN apt-get update && apt-get install -y locales  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN apt update && \
+    apt install -y curl apt-transport-https dirmngr gnupg ca-certificates && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    (echo "deb https://download.mono-project.com/repo/debian stable-buster main" | tee /etc/apt/sources.list.d/mono-official-stable.list) && \
+    apt update && \
+    apt install -y mono-complete="6.12.0.182-0xamarin1+debian10b1" git


### PR DESCRIPTION
ベースイメージをbullseyeへ更新しました。

Dockerhubへ下記のタグでpush済みです。
conchoid/mono:v6.12.0-bullseye
