### PR TITLE
Update to trixie

### DIFF
--- a/.update/update.md
+++ b/.update/update.md
@@ -1,0 +1,51 @@
+# Dockerfile ベースイメージ更新手順
+
+## 概要
+mono/6.12.0-bookworm/Dockerfileのベースイメージを `debian:bookworm-slim` (Debian 12) から `debian:trixie-slim` (Debian 13) に更新する。
+
+## 更新手順
+
+### 1. ベースイメージの更新
+Dockerfileの1行目を以下のように変更する：
+
+**変更前:**
+```dockerfile
+FROM debian:bookworm-slim
+```
+
+**変更後:**
+```dockerfile
+FROM debian:trixie-slim
+```
+
+### 2. 動作確認
+以下のコマンドでDockerイメージをビルドし、正常に動作することを確認する：
+
+```bash
+cd mono/6.12.0-bookworm
+docker build -t conchoid/mono:6.12.0-trixie .
+```
+
+### 3. 互換性チェック
+Debian 13への更新により、以下の点を確認する：
+
+- パッケージの互換性（apt-getでインストールしているパッケージが利用可能か）
+- Mono 6.12.0の動作確認
+- GPGキーリングの設定が正常に動作するか
+- Mono公式リポジトリ（stable-buster）の互換性
+- ロケール設定の確認
+
+### 4. テスト実行
+実際のMonoプロジェクトでイメージを使用し、以下を確認する：
+
+- ビルドが正常に完了するか
+- Monoランタイムが正常に動作するか
+- 依存関係の解決が正常に行われるか
+- 実行時エラーが発生しないか
+
+## 注意事項
+- Debian 13 (trixie) は比較的新しいリリースのため、一部のパッケージやツールのバージョンが変更されている可能性がある
+- Mono公式リポジトリが`stable-buster`を指定しているため、Debian 13との互換性を確認する必要がある
+- 問題が発生した場合は、パッケージのバージョン指定や代替パッケージの検討が必要になる場合がある
+- GPGキーリングの設定方法が変更されている可能性があるため、キー取得方法の確認が必要
+

--- a/6.12.0-trixie/Dockerfile
+++ b/6.12.0-trixie/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:trixie-slim
+
+# Preset locale to en_US.UTF-8
+# https://docs.docker.com/samples/library/debian/#locales
+RUN apt-get update && apt-get install -y locales  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN apt update && \
+    apt install -y curl apt-transport-https dirmngr gnupg ca-certificates && \
+    gpg --homedir /tmp --no-default-keyring --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    gpg --homedir /tmp --no-default-keyring --export 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF | gpg --dearmor -o /usr/share/keyrings/mono-official-archive-keyring.gpg && \
+    (echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/debian stable-buster main" | tee /etc/apt/sources.list.d/mono-official-stable.list) && \
+    apt update && \
+    apt install -y mono-complete="6.12.0.200-0xamarin2+debian10b1" git
+


### PR DESCRIPTION
base imageをtrixieに更新しました。

Dockerhubには以下のタグでpushしています。
`conchoid/mono:v6.12.0-trixie`
